### PR TITLE
Use exceptions to handle Calculator errors

### DIFF
--- a/backend/Calculator.cpp
+++ b/backend/Calculator.cpp
@@ -2,7 +2,7 @@
 
 
 Calculator::Calculator() {
-	std::stringstream *s = new stringstream;
+	std::stringstream *s = new std::stringstream;
 	this->ip = s;
 	this->ts = new TokenStream(ip);
 	this->parser = new Parser(ts);
@@ -27,8 +27,8 @@ Calculator::~Calculator() {
 double Calculator::calculate(std::string s) {
 	// if ip is a stringstream, we have to dynamically cast it to one, because
 	// it is saved as pointer to the base class (istream)
-	if (typeid(*ip) == typeid(stringstream)){
-		*(dynamic_cast<stringstream*>(ip)) << s;
+	if (typeid(*ip) == typeid(std::stringstream)){
+		*(dynamic_cast<std::stringstream*>(ip)) << s;
 	} else {
 		throw "calculate() can't be called";
 	}

--- a/backend/Parser.cpp
+++ b/backend/Parser.cpp
@@ -9,7 +9,6 @@ Parser::Parser(TokenStream *tsp) {
 }
 
 double Parser::expr(bool getNeeded) {
-	this->clearError();
 	double left = term(getNeeded);
 
 	while(true) {
@@ -44,8 +43,7 @@ double Parser::term(bool getNeeded) {
 			case '/': {
 				double right = power(true);
 				if(right == 0) {
-					this->setError("ERROR: division by zero");
-					return 0;
+					throw "ERROR: division by zero";
 				}
 				left /= right;
 				break;
@@ -87,8 +85,7 @@ double Parser::primary(bool getNeeded) {
 			subExpr = true; // do not save subexpression to memory
 			double expression = expr(true);
 			if ((*tsp).current().kind != ')') {
-				this->setError("ERROR: ) expected!");
-				return 0;
+				throw "ERROR: ) expected";
 			}
 			(*tsp).get(); // drop the ")" at the end of the expression from currentToken
 			return expression;
@@ -96,8 +93,7 @@ double Parser::primary(bool getNeeded) {
 		case 'v': { // variable
 			int varNumber = stoi((*tsp).current().strValue) - 1;
 			if(varNumber > MAX_MEMORY) {
-				this->setError("ERROR: variable number invalid!");
-				return 0;
+				throw "ERROR: variable number invalid";
 			}
 			(*tsp).get(); // get next token
 
@@ -119,13 +115,8 @@ double Parser::primary(bool getNeeded) {
 		case 't': {
 			return tan(primary(true));
 		}
-		case '#': { // skip
-			this->setError("");
-			return 0;
-		}
 		default:
-			this->setError("ERROR: not a primary!");
-			return 0;
+			throw "ERROR: not a primary";
 	}
 }
 
@@ -140,20 +131,4 @@ std::string Parser::getMemory() {
 	}
 
 	return out.str();
-}
-
-bool Parser::getError() {
-	return this->error.state;
-}
-
-std::string Parser::getErrorMsg() {
-	return this->error.message;
-}
-
-void Parser::setError(std::string msg) {
-	this->error = {true, msg};
-}
-
-void Parser::clearError() {
-	this->error = {false, ""};
 }

--- a/backend/Parser.h
+++ b/backend/Parser.h
@@ -2,7 +2,6 @@
 #define _PARSER_H_
 
 #include "TokenStream.h"
-#include "error.h"
 
 #define MAX_MEMORY 100
 
@@ -13,7 +12,6 @@ class Parser {
 		bool memoryFull;
 		bool subExpr;
 		TokenStream *tsp;
-		Error error = {false, ""};
 	public:
 		Parser(TokenStream *tsp);
 
@@ -23,11 +21,6 @@ class Parser {
 		double primary(bool getNeeded);
 
 		std::string getMemory();
-
-		bool getError();
-		std::string getErrorMsg();
-		void setError(std::string msg);
-		void clearError();
 };
 
 #endif

--- a/backend/TokenStream.cpp
+++ b/backend/TokenStream.cpp
@@ -70,7 +70,7 @@ Token TokenStream::get() {
 			// read characters until we encounter a space or (
 			// strValue can't be empty, otherwise the overwriting by character won't work
 			this->currentToken.strValue = "placeholder";
-			for (inputLen = 0; (c = this->ip->get()) != '(' && !isspace(c); inputLen++) {
+			for (inputLen = 0; (c = this->ip->get()) != '(' && !isspace(c) && c != EOF; inputLen++) {
 				this->currentToken.strValue[inputLen] = c;
 			}
 			// cat strValue at the end of the function name
@@ -87,8 +87,8 @@ Token TokenStream::get() {
 			} else if((this->currentToken.strValue) == "tan") {
 				this->currentToken.kind = 't';
 			} else{
-				std::cout << "ERROR: not a valid function: " << this->currentToken.strValue << "\n";
-				this->currentToken = {'#', "skip", 0};
+				resetStream();
+				throw "ERROR: not a valid function";
 			}
 
 			break;
@@ -100,8 +100,8 @@ Token TokenStream::get() {
 			int varNumber;
 			*(this->ip) >> nextChar;
 			if(!isdigit(nextChar)) {
-				std::cout << "ERROR: invalid variable number: " << nextChar << "\n";
-				this->currentToken = {'#', "skip", 0};
+				resetStream();
+				throw "ERROR: invalid variable number";
 			} else {
 				this->ip->putback(nextChar);
 				*(this->ip) >> varNumber;
@@ -110,9 +110,8 @@ Token TokenStream::get() {
 			}
 			break;
 		default: // error
-			std::cout << "ERROR: invalid input: " << ch << "\n";
-			this->currentToken = {'#', "skip", 0};
-			break;
+			resetStream();
+			throw "ERROR: invalid input";
 	}
 
 	return this->currentToken;

--- a/gui/CalculatorApp.cpp
+++ b/gui/CalculatorApp.cpp
@@ -9,6 +9,11 @@ CalculatorApp::CalculatorApp(SDL_Window *win, SDL_Renderer *ren) : App(win, ren)
 		win, ren, 30, 30, 600, 400, "", 18
 	};
 
+	// widget to display the errors
+	TextOutput *errors = new TextOutput{
+		win, ren, 0, 500, 600, 600, "", 24
+	};
+
 	// widget for input prompt
 	TextOutput *prompt = new TextOutput{
 		win, ren, 0, 450, 600, 500, "Eingabe ('q' zum Beenden): ", 24
@@ -17,11 +22,12 @@ CalculatorApp::CalculatorApp(SDL_Window *win, SDL_Renderer *ren) : App(win, ren)
 	// widget for input
 	this->calculator = new Calculator{};
 	CalculatorInput *input = new CalculatorInput{
-		win, ren, 300, 450, 600, 500, "", 24, memory, this->calculator
+		win, ren, 300, 450, 600, 500, "", 24, memory, errors, this->calculator
 	};
 
 
 	this->widgets.push_back(memory);
+	this->widgets.push_back(errors);
 	this->widgets.push_back(prompt);
 	this->widgets.push_back(input);
 }

--- a/gui/CalculatorInput.cpp
+++ b/gui/CalculatorInput.cpp
@@ -3,8 +3,10 @@
 
 CalculatorInput::CalculatorInput(
 	SDL_Window *w, SDL_Renderer *r, int x1, int y1, int x2, int y2,
-	std::string text, int fontSize, TextOutput *output, Calculator *calculator
+	std::string text, int fontSize, TextOutput *output, TextOutput *errors,
+	Calculator *calculator
 ) : LineInput(w, r, x1, y1, x2, y2, text, fontSize) {
+	this->errors = errors;
 	this->output = output;
 	this->calculator = calculator;
 }
@@ -16,9 +18,20 @@ App * CalculatorInput::handleEvent(SDL_Event event) {
 	}
 
 	if(event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_RETURN) {
-		this->calculator->calculate(this->text);
-		this->output->setText(this->calculator->getMemory());
-		this->text = "";
+		try {
+			this->calculator->calculate(this->text);
+			this->output->setText(this->calculator->getMemory());
+			this->errors->setText("");
+			this->text = "";
+		}
+		catch (const char *s) {
+			std::string errorString = s;
+			errorString += ": (";
+			errorString += this->text;
+			errorString += ")";
+			this->errors->setText(errorString);
+			this->text = "";
+		}
 	}
 	return nextApp; // if it's nullptr, we want to stay in the calculator
 }

--- a/gui/CalculatorInput.h
+++ b/gui/CalculatorInput.h
@@ -9,11 +9,13 @@
 class CalculatorInput : public LineInput{
 private:
 	TextOutput *output;
+	TextOutput *errors;
 	Calculator *calculator;
 public:
 	CalculatorInput(
 		SDL_Window *w, SDL_Renderer *r, int x1, int y1, int x2, int y2,
-		std::string text, int fontSize, TextOutput *output, Calculator *c
+		std::string text, int fontSize, TextOutput *output, TextOutput *errors,
+		Calculator *c
 	);
 
 	virtual App * handleEvent(SDL_Event event);


### PR DESCRIPTION
This PR fixes 2 problems: it doesn't fill a memory position with 0 if an error occurs, and it shows errors on the screen as they occur in the CalculatorApp. 